### PR TITLE
COMCL-452: Fix issues with Extension usage

### DIFF
--- a/CRM/CivirulesActions/Participant/AddToZoom.php
+++ b/CRM/CivirulesActions/Participant/AddToZoom.php
@@ -157,7 +157,7 @@ class CRM_CivirulesActions_Participant_AddToZoom extends CRM_Civirules_Action{
     }
   }
 
-  public function getJoinUrl($object){
+  public static function getJoinUrl($object){
     $eventId = $object->event_id;
     $accountId = CiviZoomUtils::getZoomAccountIdByEventId($eventId);
     $settings = CiviZoomUtils::getZoomSettings();

--- a/CRM/NcnCiviZoom/Form/DataSync.php
+++ b/CRM/NcnCiviZoom/Form/DataSync.php
@@ -189,7 +189,7 @@ class CRM_NcnCiviZoom_Form_DataSync extends CRM_Core_Form {
     CRM_Core_BAO_Setting::setItem($zoomSettings, ZOOM_SETTINGS, 'zoom_settings');
     $result['message'] = ts('Your Settings have been saved');
     $result['type'] = 'success';
-    $redirectUrl    = CRM_Utils_System::url('civicrm/Zoom/zoomdatasync', 'reset=1');
+    $redirectUrl    = CRM_Utils_System::url('civicrm/admin/zoomdatasync', 'reset=1');
 
     CRM_Core_Session::setStatus($result['message'], ts('Zoom Settings'), $result['type']);
     CRM_Utils_System::redirect($redirectUrl);

--- a/CRM/NcnCiviZoom/Form/Settings.php
+++ b/CRM/NcnCiviZoom/Form/Settings.php
@@ -12,6 +12,7 @@ class CRM_NcnCiviZoom_Form_Settings extends CRM_Core_Form {
 
   public $_id = NULL;
   public $_act = NULL;
+  public string $zoomName;
 
   public function preProcess() {
     CRM_Utils_System::setTitle(ts("Zoom Account Settings"));
@@ -19,7 +20,7 @@ class CRM_NcnCiviZoom_Form_Settings extends CRM_Core_Form {
     $this->_act = CRM_Utils_Request::retrieve('act', 'Positive', $this);
     //setting the user context to zoom accounts list page
     $session = CRM_Core_Session::singleton();
-    $session->pushUserContext(CRM_Utils_System::url('civicrm/Zoom/zoomaccounts',"reset=1"));
+    $session->pushUserContext(CRM_Utils_System::url('civicrm/admin/zoomaccounts',"reset=1"));
     parent::preProcess();
   }
 
@@ -147,8 +148,8 @@ class CRM_NcnCiviZoom_Form_Settings extends CRM_Core_Form {
           $rows[$Id]['secret_key'] = substr($values['secret_key'], 0, 4).(str_repeat('*',strlen($values['secret_key']) - 4));
         }
         if (!$deleteAction) {
-          $editURL = CRM_Utils_System::href('Edit', 'civicrm/Zoom/zoomaccounts', 'reset=1&act='.CRM_Core_Action::UPDATE.'&id='.$Id);
-          $deleteURL = CRM_Utils_System::href('Delete', 'civicrm/Zoom/zoomaccounts', 'reset=1&act='.CRM_Core_Action::DELETE.'&id='.$Id);
+          $editURL = CRM_Utils_System::href('Edit', 'civicrm/admin/zoomaccounts', 'reset=1&act='.CRM_Core_Action::UPDATE.'&id='.$Id);
+          $deleteURL = CRM_Utils_System::href('Delete', 'civicrm/admin/zoomaccounts', 'reset=1&act='.CRM_Core_Action::DELETE.'&id='.$Id);
           $rows[$Id]['action'] = sprintf("<span>%s &nbsp;/&nbsp; %s</span>", $editURL, $deleteURL, $Id);
           $testResult = self::testAPIConnectionSettings($Id);
           $ext = 'ncn-civi-zoom';
@@ -185,7 +186,7 @@ class CRM_NcnCiviZoom_Form_Settings extends CRM_Core_Form {
     //Set default Values
     $this->setDefaults($defaults);
 
-    $this->addFormRule(array('CRM_NcnCiviZoom_Form_Settings', 'formRule'));
+    $this->addFormRule([$this, 'formRule']);
     parent::buildQuickForm();
   }
 
@@ -256,7 +257,7 @@ class CRM_NcnCiviZoom_Form_Settings extends CRM_Core_Form {
 
     if ($buttonName == $this->getButtonName('upload', 'done')) {
       $result = self::testAPIConnectionSettings($this->_id);
-      $redirectUrl = CRM_Utils_System::url('civicrm/Zoom/zoomaccounts', 'reset=1&act='.$this->_act."&id=".$this->_id);
+      $redirectUrl = CRM_Utils_System::url('civicrm/admin/zoomaccounts', 'reset=1&act='.$this->_act."&id=".$this->_id);
     }
     else {
       $tableName = CRM_NcnCiviZoom_Constants::ZOOM_ACCOUNT_SETTINGS;
@@ -327,7 +328,7 @@ class CRM_NcnCiviZoom_Form_Settings extends CRM_Core_Form {
         $result['message'] = ts('Your Settings have been saved');
         $result['type'] = 'success';
       }
-      $redirectUrl    = CRM_Utils_System::url('civicrm/Zoom/zoomaccounts', 'reset=1');
+      $redirectUrl    = CRM_Utils_System::url('civicrm/admin/zoomaccounts', 'reset=1');
     }
 
     CRM_Core_Session::setStatus($result['message'], ts('Zoom Account Settings'), $result['type']);

--- a/CRM/NcnCiviZoom/Utils.php
+++ b/CRM/NcnCiviZoom/Utils.php
@@ -1214,6 +1214,7 @@ class CRM_NcnCiviZoom_Utils {
         'is_reserved' => 1,
         'is_counted' => 0,
         'visibility_id' => "admin",
+        'weight' => 1
       ]);
     }
     $tableName = CRM_NcnCiviZoom_Constants::ZOOM_REGISTRANTS_TABLE_NAME;

--- a/templates/CRM/NcnCiviZoom/Form/Settings.tpl
+++ b/templates/CRM/NcnCiviZoom/Form/Settings.tpl
@@ -39,7 +39,7 @@
   {if !$id}
     {if !$deleteAction}
       <div class="crm-submit-buttons">
-         <a class="button crm-button" href="{crmURL p='civicrm/Zoom/zoomaccounts' q='act=1&reset=1'}" id="newAccount"><i class="crm-i fa-plus-circle"></i> {ts}Add New zoom account{/ts}</a>
+         <a class="button crm-button" href="{crmURL p='civicrm/admin/zoomaccounts' q='act=1&reset=1'}" id="newAccount"><i class="crm-i fa-plus-circle"></i> {ts}Add New zoom account{/ts}</a>
       </div>
       <h1>List of configured zoom accounts</h1>
     {/if}


### PR DESCRIPTION
## Description
Port [PR](https://github.com/coopsymbiotic/ncn-civi-zoom/pull/1)

This pull request addresses issues encountered while testing the extension:

- The settings page path was updated to `civicrm/admin/zoomaccounts` in [this commit](https://github.com/coopsymbiotic/ncn-civi-zoom/commit/47512c0a784f28ecd5346be02524d2f16f2724ee), but the corresponding change did not reflect on the settings page link. This PR corrects the issue in [this commit](https://github.com/coopsymbiotic/ncn-civi-zoom/commit/2a6c74879294491e1cae4d2b8ff1bedd857c8f52).

- The execution of the `Getrecentzoomregistrants` scheduled job fails due to an attempt to create a new participant status type, "Cancelled through zoom," without specifying a default value for the `weight` field. This PR addresses this issue as well in [this commit](https://github.com/coopsymbiotic/ncn-civi-zoom/commit/1c4713af6b7f8bf1cedc076754606ad634ac6b8a).