### PR TITLE
COMCL-825: Use URL to detect customdata type is loaded on event form

### DIFF
--- a/ncn_civi_zoom.php
+++ b/ncn_civi_zoom.php
@@ -236,7 +236,7 @@ function ncn_civi_zoom_civicrm_buildForm($formName, &$form) {
 
   //Add the zoom account list to the form once the custom datatype is loaded
   if($formName == 'CRM_Custom_Form_CustomDataByType'){
-    if($form->_cdType == 'Event' && $form->_type == 'Event'){
+    if(CRM_Utils_Request::retrieve('type', 'String', NULL, TRUE) == 'Event') {
       $customAccountId = CRM_NcnCiviZoom_Utils::getAccountIdCustomField();
       if(!empty($customAccountId)){
         CRM_NcnCiviZoom_Utils::addZoomListToEventForm($form);
@@ -245,7 +245,7 @@ function ncn_civi_zoom_civicrm_buildForm($formName, &$form) {
           'template' => "{$templatePath}/CRM/NcnCiviZoom/Event/Form/ManageEvent/Extra.tpl"
         ));
       }
-    }
+    } 
   }
 
   //Add the zoom account list to the form once the form is loaded


### PR DESCRIPTION
## Overview
This PR resolves the issue with the extension not being able to hide the populate the account ID, this issue happened because the _type field is no longer accessible in CiviCRM version 5.75 where the extension was tested.


## Before
<img width="951" alt="Screenshot 2024-09-16 at 09 18 28" src="https://github.com/user-attachments/assets/a02201a6-c313-40b5-aeaa-8a38d2fa96c3">

## After
<img width="833" alt="Screenshot 2024-09-16 at 09 22 09" src="https://github.com/user-attachments/assets/7e17a188-1304-4267-a9ef-df7f2de08ad2">
