### PR TITLE
COMCL-890: Ensure Event can be saved without ZoomAccountId field

### DIFF
--- a/CRM/CivirulesActions/Participant/AddToZoom.php
+++ b/CRM/CivirulesActions/Participant/AddToZoom.php
@@ -175,6 +175,11 @@ class CRM_CivirulesActions_Participant_AddToZoom extends CRM_Civirules_Action{
       return [null, null, null];
     }
 
+    if (empty($accountId)) {
+      Civi::log()->warning("ncn-civi-zoom: AddToZoom: accountId for $url was empty");
+      return [null, null, null];
+    }
+
     [$isResponseOK, $result] = CiviZoomUtils::zoomApiRequest($accountId, $url);
 
     if (empty($result['join_url'])) {


### PR DESCRIPTION
## Overview

Before this PR users were not able to save events because of the Zoom Account ID check hook that throws an exception when the AccountID is empty and not empty (i.e. the value is just being set and not yet submitted to DB), in this PR we have handled this scenario to ensure the user can continue to save an event regardless of the value of the Account ID field.

