### PR TITLE
CIVIMM-293: Fix permission label

### DIFF
--- a/ncn_civi_zoom.php
+++ b/ncn_civi_zoom.php
@@ -66,7 +66,10 @@ function ncn_civi_zoom_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
 
 function ncn_civi_zoom_civicrm_permission(&$permissions) {
   $prefix = ts('NcnCiviZoom') . ': '; // name of extension or module
-  $permissions['administer Zoom'] = $prefix . ts('administer Zoom');
+  $permissions['administer Zoom'] = [
+    'label' => $prefix . ts('administer Zoom'),
+    'description' => $prefix . ts('administer Zoom'),
+  ];
 }
 
 /**


### PR DESCRIPTION
## Overview
CiviCRM 5.0+ uses a newer format for declaring permissions. As of Civi 5.71, the old format is deprecated.